### PR TITLE
Fix close on ipad/tablets

### DIFF
--- a/L.Control.Basemaps.js
+++ b/L.Control.Basemaps.js
@@ -104,6 +104,15 @@ L.Control.Basemaps = L.Control.extend({
                         var altIdx = (i + 1) % this.options.basemaps.length;
                         L.DomUtil.removeClass(container.getElementsByClassName("basemap alt")[0], "alt");
                         L.DomUtil.addClass(container.getElementsByClassName("basemap")[altIdx], "alt");
+
+			if(L.Browser.touch) {
+			    // fix close on ipad tablets ...
+			    if(L.DomUtil.hasClass(container, "closed")){
+				L.DomUtil.removeClass(container, "closed");
+			    }else{
+				L.DomUtil.addClass(container, "closed");
+			    }
+			}
                     }
                 },
                 this


### PR DESCRIPTION
Hello,

I'm using Leafet.Basemaps and it's working like a charm on desktop.
Some of my end users are using ipad or tablet and the basemaps selection UI was not closing properly for them. This is the workaround solution I could find.
Hope it can be useful. 